### PR TITLE
Fix type definitions of DynamoDB Client and Table

### DIFF
--- a/mypy_boto3_builder/type_maps/method_type_map.py
+++ b/mypy_boto3_builder/type_maps/method_type_map.py
@@ -79,7 +79,10 @@ TYPE_MAP: ServiceTypeMap = {
         "Object": {"copy": {"CopySource": s3_copy_source_type}},
     },
     ServiceNameCatalog.dynamodb: {
-        "Client": {
+        "Table": {
+            "batch_writer": {
+                "return": ExternalImport(ImportString("boto3", "dynamodb", "table"), "BatchWriter")
+            },
             "query": {
                 "KeyConditionExpression": TypeSubscript(
                     Type.Union, [Type.str, TypeClass(ConditionBase)]
@@ -89,11 +92,6 @@ TYPE_MAP: ServiceTypeMap = {
             "scan": {
                 "FilterExpression": TypeSubscript(Type.Union, [Type.str, TypeClass(ConditionBase)]),
             },
-        },
-        "Table": {
-            "batch_writer": {
-                "return": ExternalImport(ImportString("boto3", "dynamodb", "table"), "BatchWriter")
-            }
         },
     },
 }


### PR DESCRIPTION
In DynamoDB, `Client` accepts only str as expression, on the other hand, `Table` accepts ConditionBase as expression as described in the documents below.
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.query
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.scan
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.query
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.scan

 So I fixed the method type map.