### PR TITLE
fix: ClientErrorResponseTypeDef is Error

### DIFF
--- a/mypy_boto3_builder/botocore_stubs_static/exceptions.pyi
+++ b/mypy_boto3_builder/botocore_stubs_static/exceptions.pyi
@@ -21,7 +21,7 @@ class ResponseMetadataTypeDef(TypedDict):
     RetryAttempts: int
 
 class ClientErrorResponseTypeDef(TypedDict, total=False):
-    error: ClientErrorResponseError
+    Error: ClientErrorResponseError
     ResponseMetadata: ResponseMetadataTypeDef
 
 class BotoCoreError(Exception):


### PR DESCRIPTION
Migrating away from botocore-types, here is the change I've seen.

https://github.com/boto/botocore/blob/develop/botocore/exceptions.py#L425