### PR TITLE
Version 5.0.0

### DIFF
--- a/.github/workflows/publish_boto3_stubs.yml
+++ b/.github/workflows/publish_boto3_stubs.yml
@@ -76,7 +76,7 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           rm -rf mypy_boto3_output/*
-          scripts/build.sh -b $VERSION
+          python -m mypy_boto3_builder mypy_boto3_output -b $VERSION
       - name: Install dependencies for publishing
         if: steps.vars.outputs.version
         run: |
@@ -87,4 +87,4 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          scripts/release.sh
+          ./scripts/release.sh

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -1,0 +1,64 @@
+name: Sanity check
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      boto3_version:
+        description: Target boto3 version
+
+jobs:
+  publish-boto3-stubs:
+    env:
+      PIP_NO_CACHE_DIR: false
+      PIP_USER: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract versions
+        id: vars
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const { getBoto3Version, getBotocoreVersion } = require('./.github/workflows/helpers.js')
+
+            const boto3Version = (context.payload.inputs && context.payload.inputs.boto3_version) ? context.payload.inputs.boto3_version : await getBoto3Version()
+            const botocoreVersion = getBotocoreVersion(boto3Version)
+            core.info(`Boto3 version ${boto3Version}`)
+            core.info(`Botocore version ${botocoreVersion}`)
+            core.setOutput('version', boto3Version)
+            core.setOutput('boto3-version', boto3Version)
+            core.setOutput('botocore-version', botocoreVersion)
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install boto3
+        env:
+          BOTO3_VERSION: ${{ steps.vars.outputs.boto3-version }}
+          BOTOCORE_VERSION: ${{ steps.vars.outputs.botocore-version }}
+        run: |
+          python -m pip install -U boto3==${BOTO3_VERSION} botocore==${BOTOCORE_VERSION}
+      - name: Install dependencies
+        run: |
+          python -m pip install -U poetry pip wheel
+          poetry config virtualenvs.create false
+          poetry install -n
+          sudo npm install -g pyright
+      - name: Build packages
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          rm -rf mypy_boto3_output/*
+          python -m mypy_boto3_builder mypy_boto3_output -b $VERSION
+      - name: Install master packages
+        run: |
+          ./scripts/install.sh master
+      - name: Check output
+        run: |
+          python ./scripts/check_output.py -p ./mypy_boto3_output

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.5-alpine3.13
 
 RUN apk add --no-cache --virtual .build-deps \
     gcc libc-dev \
-    && python -m pip install --no-cache-dir regex \
+    && python -m pip install --no-cache-dir regex==2021.7.6 \
     && apk del --no-cache .build-deps
 
 RUN mkdir -p /builder/scripts

--- a/docs/mypy_boto3_builder/cli_parser.md
+++ b/docs/mypy_boto3_builder/cli_parser.md
@@ -7,12 +7,11 @@ CLI parser.
 - [mypy-boto3-builder](../README.md#mypy_boto3_builder) / [Modules](../MODULES.md#mypy-boto3-builder-modules) / [Mypy Boto3 Builder](index.md#mypy-boto3-builder) / Cli Parser
     - [Namespace](#namespace)
     - [get_absolute_path](#get_absolute_path)
-    - [get_service_name](#get_service_name)
     - [parse_args](#parse_args)
 
 ## Namespace
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L47)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L27)
 
 ```python
 dataclass
@@ -23,7 +22,7 @@ CLI arguments namespace.
 
 ## get_absolute_path
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L15)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L13)
 
 ```python
 def get_absolute_path(path: str) -> Path:
@@ -39,31 +38,9 @@ Get absolute path from a string.
 
 Absolute path.
 
-## get_service_name
-
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L28)
-
-```python
-def get_service_name(name: str) -> ServiceName:
-```
-
-Convert boto3 service name to ServiceName.
-
-#### Arguments
-
-- `name` - Service name.
-
-#### Raises
-
-- `argparse.ArgumentTypeError` - If service not found.
-
-#### See also
-
-- [ServiceName](service_name.md#servicename)
-
 ## parse_args
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L63)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/cli_parser.py#L44)
 
 ```python
 def parse_args(args: Sequence[str]) -> Namespace:

--- a/docs/mypy_boto3_builder/main.md
+++ b/docs/mypy_boto3_builder/main.md
@@ -12,7 +12,7 @@ Main entrypoint for builder.
 
 ## generate_docs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L156)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L169)
 
 ```python
 def generate_docs(
@@ -36,7 +36,7 @@ Generate service and master docs.
 
 ## generate_stubs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L109)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L120)
 
 ```python
 def generate_stubs(
@@ -60,7 +60,7 @@ Generate service and master stubs.
 
 ## get_available_service_names
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L33)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L37)
 
 ```python
 def get_available_service_names(session: Session) -> List[ServiceName]:
@@ -78,7 +78,7 @@ A list of supported services.
 
 ## main
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L57)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/main.py#L59)
 
 ```python
 def main() -> None:

--- a/docs/mypy_boto3_builder/service_name.md
+++ b/docs/mypy_boto3_builder/service_name.md
@@ -20,7 +20,7 @@ Description for boto3 service.
         - [ServiceName().pypi_name](#servicenamepypi_name)
         - [ServiceName().underscore_name](#servicenameunderscore_name)
     - [ServiceNameCatalog](#servicenamecatalog)
-        - [ServiceNameCatalog.create](#servicenamecatalogcreate)
+        - [ServiceNameCatalog.add](#servicenamecatalogadd)
         - [ServiceNameCatalog.find](#servicenamecatalogfind)
 
 ## ServiceName
@@ -218,16 +218,20 @@ class ServiceNameCatalog():
 
 Finder for boto3 services by name.
 
-### ServiceNameCatalog.create
+### ServiceNameCatalog.add
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/service_name.py#L490)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/service_name.py#L232)
 
 ```python
-@staticmethod
-def create(name: str) -> ServiceName:
+@classmethod
+def add(name: str, class_name: str) -> ServiceName:
 ```
 
-Create ServiceName for unknown service.
+Add new ServiceName to catalog or modify existing one.
+
+#### Returns
+
+New ServiceName or modified if it exists.
 
 #### See also
 
@@ -235,7 +239,7 @@ Create ServiceName for unknown service.
 
 ### ServiceNameCatalog.find
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/service_name.py#L471)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/service_name.py#L213)
 
 ```python
 @classmethod

--- a/docs/mypy_boto3_builder/structures/package.md
+++ b/docs/mypy_boto3_builder/structures/package.md
@@ -9,7 +9,7 @@ Parent class for all package structures.
 
 ## Package
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/structures/package.py#L9)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/structures/package.py#L8)
 
 ```python
 class Package():

--- a/docs/mypy_boto3_builder/utils/nice_path.md
+++ b/docs/mypy_boto3_builder/utils/nice_path.md
@@ -6,13 +6,28 @@ Path that represents it as relative to workdir.
 
 - [mypy-boto3-builder](../../README.md#mypy_boto3_builder) / [Modules](../../MODULES.md#mypy-boto3-builder-modules) / [Mypy Boto3 Builder](../index.md#mypy-boto3-builder) / [Utils](index.md#utils) / NicePath
     - [NicePath](#nicepath)
+        - [NicePath().walk](#nicepathwalk)
 
 ## NicePath
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/utils/nice_path.py#L7)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/utils/nice_path.py#L8)
 
 ```python
 class NicePath(type(Path())):
 ```
 
 Path that represents it as relative to workdir.
+
+### NicePath().walk
+
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/utils/nice_path.py#L30)
+
+```python
+def walk(exclude: Iterable[Path] = tuple()) -> Iterator[Path]:
+```
+
+Walk files except for `exclude`.
+
+#### Yields
+
+Existing Path.

--- a/docs/mypy_boto3_builder/utils/strings.md
+++ b/docs/mypy_boto3_builder/utils/strings.md
@@ -6,8 +6,10 @@ Multiple string utils collection.
 
 - [mypy-boto3-builder](../../README.md#mypy_boto3_builder) / [Modules](../../MODULES.md#mypy-boto3-builder-modules) / [Mypy Boto3 Builder](../index.md#mypy-boto3-builder) / [Utils](index.md#utils) / Strings
     - [get_anchor_link](#get_anchor_link)
+    - [get_botocore_class_name](#get_botocore_class_name)
     - [get_class_prefix](#get_class_prefix)
     - [get_line_with_indented](#get_line_with_indented)
+    - [get_min_build_version](#get_min_build_version)
     - [get_short_docstring](#get_short_docstring)
     - [is_reserved](#is_reserved)
 
@@ -20,6 +22,16 @@ def get_anchor_link(text: str) -> str:
 ```
 
 Convert header to markdown anchor link.
+
+## get_botocore_class_name
+
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/utils/strings.py#L144)
+
+```python
+def get_botocore_class_name(metadata: Dict[(str, str)]) -> str:
+```
+
+Get Botocore class name from Service metadata.
 
 ## get_class_prefix
 
@@ -61,6 +73,18 @@ Fixes invalid unindent.
 #### Returns
 
 A string with first line and following indented lines.
+
+## get_min_build_version
+
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/utils/strings.py#L162)
+
+```python
+def get_min_build_version(version: str) -> str:
+```
+
+Get min version 5 micro releases lower that `version`.
+
+Minimum micro is 0.
 
 ## get_short_docstring
 

--- a/docs/mypy_boto3_builder/writers/boto3_stubs_package.md
+++ b/docs/mypy_boto3_builder/writers/boto3_stubs_package.md
@@ -10,7 +10,7 @@ boto3-stubs package writer.
 
 ## write_boto3_stubs_docs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/boto3_stubs_package.py#L92)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/boto3_stubs_package.py#L93)
 
 ```python
 def write_boto3_stubs_docs(

--- a/docs/mypy_boto3_builder/writers/boto3_stubs_package.md
+++ b/docs/mypy_boto3_builder/writers/boto3_stubs_package.md
@@ -10,13 +10,13 @@ boto3-stubs package writer.
 
 ## write_boto3_stubs_docs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/boto3_stubs_package.py#L95)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/boto3_stubs_package.py#L92)
 
 ```python
 def write_boto3_stubs_docs(
     package: Boto3StubsPackage,
     output_path: Path,
-) -> List[Path]:
+) -> None:
 ```
 
 Generate docs for boto3-stubs package.
@@ -34,7 +34,7 @@ def write_boto3_stubs_package(
     package: Boto3StubsPackage,
     output_path: Path,
     generate_setup: bool,
-) -> List[Path]:
+) -> None:
 ```
 
 Generate stubs for boto3-stubs package.

--- a/docs/mypy_boto3_builder/writers/botocore_stubs_package.md
+++ b/docs/mypy_boto3_builder/writers/botocore_stubs_package.md
@@ -15,7 +15,7 @@ botocore-stubs package writer.
 def write_botocore_stubs_package(
     output_path: Path,
     generate_setup: bool,
-) -> List[Path]:
+) -> None:
 ```
 
 Generate botocore-stubs stub files.

--- a/docs/mypy_boto3_builder/writers/master_package.md
+++ b/docs/mypy_boto3_builder/writers/master_package.md
@@ -9,14 +9,14 @@ Master package writer.
 
 ## write_master_package
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/master_package.py#L19)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/master_package.py#L20)
 
 ```python
 def write_master_package(
     package: MasterPackage,
     output_path: Path,
     generate_setup: bool,
-) -> List[Path]:
+) -> None:
 ```
 
 Create mypy-boto3 stubs.

--- a/docs/mypy_boto3_builder/writers/processors.md
+++ b/docs/mypy_boto3_builder/writers/processors.md
@@ -44,7 +44,7 @@ Parsed Boto3StubsPackage.
 
 ## process_boto3_stubs_docs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L172)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L152)
 
 ```python
 def process_boto3_stubs_docs(
@@ -72,7 +72,7 @@ Parsed Boto3StubsPackage.
 
 ## process_botocore_stubs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L59)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L54)
 
 ```python
 def process_botocore_stubs(output_path: Path, generate_setup: bool) -> None:
@@ -87,7 +87,7 @@ Parse and write stubs package `botocore_stubs`.
 
 ## process_master
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L78)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L71)
 
 ```python
 def process_master(
@@ -117,7 +117,7 @@ Parsed MasterPackage.
 
 ## process_service
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L110)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L98)
 
 ```python
 def process_service(
@@ -148,7 +148,7 @@ Parsed ServicePackage.
 
 ## process_service_docs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L144)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/processors.py#L127)
 
 ```python
 def process_service_docs(

--- a/docs/mypy_boto3_builder/writers/service_package.md
+++ b/docs/mypy_boto3_builder/writers/service_package.md
@@ -10,13 +10,10 @@ Service package writer.
 
 ## write_service_docs
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/service_package.py#L158)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/service_package.py#L156)
 
 ```python
-def write_service_docs(
-    package: ServicePackage,
-    output_path: Path,
-) -> List[Path]:
+def write_service_docs(package: ServicePackage, output_path: Path) -> None:
 ```
 
 Create service docs files.
@@ -32,14 +29,14 @@ Create service docs files.
 
 ## write_service_package
 
-[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/service_package.py#L20)
+[[find in source code]](https://github.com/vemel/mypy_boto3_builder/blob/master/mypy_boto3_builder/writers/service_package.py#L21)
 
 ```python
 def write_service_package(
     package: ServicePackage,
     output_path: Path,
     generate_setup: bool,
-) -> List[Path]:
+) -> None:
 ```
 
 Create stubs files for service.

--- a/mypy_boto3_builder/cli_parser.py
+++ b/mypy_boto3_builder/cli_parser.py
@@ -9,8 +9,6 @@ from typing import List, Sequence
 
 import pkg_resources
 
-from mypy_boto3_builder.service_name import ServiceName, ServiceNameCatalog
-
 
 def get_absolute_path(path: str) -> Path:
     """
@@ -25,24 +23,6 @@ def get_absolute_path(path: str) -> Path:
     return Path(path).absolute()
 
 
-def get_service_name(name: str) -> ServiceName:
-    """
-    Convert boto3 service name to ServiceName.
-
-    Arguments:
-        name -- Service name.
-
-    Raises:
-        argparse.ArgumentTypeError -- If service not found.
-    """
-    try:
-        return ServiceNameCatalog.find(name)
-    except ValueError:
-        pass
-
-    return ServiceNameCatalog.create(name)
-
-
 @dataclass
 class Namespace:
     """
@@ -51,13 +31,14 @@ class Namespace:
 
     log_level: int
     output_path: Path
-    service_names: List[ServiceName]
+    service_names: List[str]
     build_version: str
     installed: bool
     skip_master: bool
     skip_services: bool
     builder_version: str
     generate_docs: bool
+    list_services: bool
 
 
 def parse_args(args: Sequence[str]) -> Namespace:
@@ -104,13 +85,17 @@ def parse_args(args: Sequence[str]) -> Namespace:
         nargs="*",
         metavar="SERVICE_NAME",
         help="List of AWS services, by default all services are used",
-        type=get_service_name,
         default=[],
     )
     parser.add_argument(
         "--installed",
         action="store_true",
         help="Generate already installed packages for typings folder.",
+    )
+    parser.add_argument(
+        "--list-services",
+        action="store_true",
+        help="List supported boto3 service names.",
     )
     result = parser.parse_args(args)
     result.builder_version = version
@@ -124,4 +109,5 @@ def parse_args(args: Sequence[str]) -> Namespace:
         installed=result.installed,
         builder_version=result.builder_version,
         generate_docs=result.docs,
+        list_services=result.list_services,
     )

--- a/mypy_boto3_builder/main.py
+++ b/mypy_boto3_builder/main.py
@@ -19,7 +19,11 @@ from mypy_boto3_builder.constants import (
 from mypy_boto3_builder.jinja_manager import JinjaManager
 from mypy_boto3_builder.logger import get_logger
 from mypy_boto3_builder.service_name import ServiceName, ServiceNameCatalog
-from mypy_boto3_builder.utils.strings import get_anchor_link, get_botocore_class_name
+from mypy_boto3_builder.utils.strings import (
+    get_anchor_link,
+    get_botocore_class_name,
+    get_min_build_version,
+)
 from mypy_boto3_builder.writers.processors import (
     process_boto3_stubs,
     process_boto3_stubs_docs,
@@ -83,6 +87,7 @@ def main() -> None:
         service_names.append(service_name)
 
     build_version = args.build_version or boto3_version
+    min_build_version = get_min_build_version(build_version)
     botocore_build_version = botocore_version
     if args.build_version and ".post" in args.build_version:
         post_release = args.build_version.split(".post")[-1]
@@ -94,6 +99,7 @@ def main() -> None:
         boto3_version=boto3_version,
         botocore_version=botocore_version,
         build_version=build_version,
+        min_build_version=min_build_version,
         botocore_build_version=botocore_build_version,
         builder_version=args.builder_version,
         get_anchor_link=get_anchor_link,

--- a/mypy_boto3_builder/service_name.py
+++ b/mypy_boto3_builder/service_name.py
@@ -229,14 +229,6 @@ class ServiceNameCatalog:
         except KeyError as exc:
             raise ValueError(f"Unknown service {name}") from exc
 
-    @staticmethod
-    def create(name: str) -> ServiceName:
-        """
-        Create ServiceName for unknown service.
-        """
-        class_name = "".join([i.capitalize() for i in name.split("-")])
-        return ServiceName(name, class_name)
-
     @classmethod
     def add(cls, name: str, class_name: str) -> ServiceName:
         """

--- a/mypy_boto3_builder/service_name.py
+++ b/mypy_boto3_builder/service_name.py
@@ -1,7 +1,7 @@
 """
 Description for boto3 service.
 """
-from typing import Literal, Mapping, Tuple
+from typing import Dict, Literal
 
 from mypy_boto3_builder.constants import MODULE_NAME, PYPI_NAME
 from mypy_boto3_builder.utils.strings import get_anchor_link, is_reserved
@@ -180,293 +180,35 @@ class ServiceNameCatalog:
     Finder for boto3 services by name.
     """
 
-    ITEMS: Tuple[ServiceName, ...] = (
-        ServiceName("accessanalyzer", "AccessAnalyzer"),
-        ServiceName("acm-pca", "ACMPCA"),
-        ServiceName("acm", "ACM"),
-        ServiceName("alexaforbusiness", "AlexaForBusiness"),
-        ServiceName("amp", "PrometheusService"),
-        ServiceName("amplify", "Amplify"),
-        ServiceName("amplifybackend", "AmplifyBackend"),
-        ServiceName("apigateway", "APIGateway"),
-        ServiceName("apigatewaymanagementapi", "ApiGatewayManagementApi"),
-        ServiceName("apigatewayv2", "ApiGatewayV2"),
-        ServiceName("appconfig", "AppConfig"),
-        ServiceName("appflow", "Appflow"),
-        ServiceName("appintegrations", "AppIntegrationsService"),
-        ServiceName("application-autoscaling", "ApplicationAutoScaling"),
-        ServiceName("application-insights", "ApplicationInsights"),
-        ServiceName("applicationcostprofiler", "ApplicationCostProfiler"),
-        ServiceName("appmesh", "AppMesh"),
-        ServiceName("apprunner", "AppRunner"),
-        ServiceName("appstream", "AppStream"),
-        ServiceName("appsync", "AppSync"),
-        ServiceName("athena", "Athena"),
-        ServiceName("auditmanager", "AuditManager"),
-        ServiceName("autoscaling-plans", "AutoScalingPlans"),
-        ServiceName("autoscaling", "AutoScaling"),
-        ServiceName("backup", "Backup"),
-        ServiceName("batch", "Batch"),
-        ServiceName("braket", "Braket"),
-        ServiceName("budgets", "Budgets"),
-        ServiceName("ce", "CostExplorer"),
-        ServiceName("chime", "Chime"),
-        ServiceName("cloud9", "Cloud9"),
-        ServiceName("clouddirectory", "CloudDirectory"),
-        ServiceName("cloudformation", "CloudFormation"),
-        ServiceName("cloudfront", "CloudFront"),
-        ServiceName("cloudhsm", "CloudHSM"),
-        ServiceName("cloudhsmv2", "CloudHSMV2"),
-        ServiceName("cloudsearch", "CloudSearch"),
-        ServiceName("cloudsearchdomain", "CloudSearchDomain"),
-        ServiceName("cloudtrail", "CloudTrail"),
-        ServiceName("cloudwatch", "CloudWatch"),
-        ServiceName("codeartifact", "CodeArtifact"),
-        ServiceName("codebuild", "CodeBuild"),
-        ServiceName("codecommit", "CodeCommit"),
-        ServiceName("codedeploy", "CodeDeploy"),
-        ServiceName("codeguru-reviewer", "CodeGuruReviewer"),
-        ServiceName("codeguruprofiler", "CodeGuruProfiler"),
-        ServiceName("codepipeline", "CodePipeline"),
-        ServiceName("codestar-connections", "CodeStarconnections"),
-        ServiceName("codestar-notifications", "CodeStarNotifications"),
-        ServiceName("codestar", "CodeStar"),
-        ServiceName("cognito-identity", "CognitoIdentity"),
-        ServiceName("cognito-idp", "CognitoIdentityProvider"),
-        ServiceName("cognito-sync", "CognitoSync"),
-        ServiceName("comprehend", "Comprehend"),
-        ServiceName("comprehendmedical", "ComprehendMedical"),
-        ServiceName("compute-optimizer", "ComputeOptimizer"),
-        ServiceName("config", "ConfigService"),
-        ServiceName("connect-contact-lens", "ConnectContactLens"),
-        ServiceName("connect", "Connect"),
-        ServiceName("connectparticipant", "ConnectParticipant"),
-        ServiceName("cur", "CostandUsageReportService"),
-        ServiceName("customer-profiles", "CustomerProfiles"),
-        ServiceName("databrew", "GlueDataBrew"),
-        ServiceName("dataexchange", "DataExchange"),
-        ServiceName("datapipeline", "DataPipeline"),
-        ServiceName("datasync", "DataSync"),
-        ServiceName("dax", "DAX"),
-        ServiceName("detective", "Detective"),
-        ServiceName("devicefarm", "DeviceFarm"),
-        ServiceName("devops-guru", "DevOpsGuru"),
-        ServiceName("directconnect", "DirectConnect"),
-        ServiceName("discovery", "ApplicationDiscoveryService"),
-        ServiceName("dlm", "DLM"),
-        ServiceName("dms", "DatabaseMigrationService"),
-        ServiceName("docdb", "DocDB"),
-        ServiceName("ds", "DirectoryService"),
-        ServiceName("dynamodb", "DynamoDB"),
-        ServiceName("dynamodbstreams", "DynamoDBStreams"),
-        ServiceName("ebs", "EBS"),
-        ServiceName("ec2-instance-connect", "EC2InstanceConnect"),
-        ServiceName("ec2", "EC2"),
-        ServiceName("ecr-public", "ECRPublic"),
-        ServiceName("ecr", "ECR"),
-        ServiceName("ecs", "ECS"),
-        ServiceName("efs", "EFS"),
-        ServiceName("eks", "EKS"),
-        ServiceName("elastic-inference", "ElasticInference"),
-        ServiceName("elasticache", "ElastiCache"),
-        ServiceName("elasticbeanstalk", "ElasticBeanstalk"),
-        ServiceName("elastictranscoder", "ElasticTranscoder"),
-        ServiceName("elb", "ElasticLoadBalancing"),
-        ServiceName("elbv2", "ElasticLoadBalancingv2"),
-        ServiceName("emr-containers", "EMRContainers"),
-        ServiceName("emr", "EMR"),
-        ServiceName("es", "ElasticsearchService"),
-        ServiceName("events", "EventBridge"),
-        ServiceName("finspace-data", "FinSpaceData"),
-        ServiceName("finspace", "finspace"),
-        ServiceName("firehose", "Firehose"),
-        ServiceName("fis", "FIS"),
-        ServiceName("fms", "FMS"),
-        ServiceName("forecast", "ForecastService"),
-        ServiceName("forecastquery", "ForecastQueryService"),
-        ServiceName("frauddetector", "FraudDetector"),
-        ServiceName("fsx", "FSx"),
-        ServiceName("gamelift", "GameLift"),
-        ServiceName("glacier", "Glacier"),
-        ServiceName("globalaccelerator", "GlobalAccelerator"),
-        ServiceName("glue", "Glue"),
-        ServiceName("greengrass", "Greengrass"),
-        ServiceName("greengrassv2", "GreengrassV2"),
-        ServiceName("groundstation", "GroundStation"),
-        ServiceName("guardduty", "GuardDuty"),
-        ServiceName("health", "Health"),
-        ServiceName("healthlake", "HealthLake"),
-        ServiceName("honeycode", "Honeycode"),
-        ServiceName("iam", "IAM"),
-        ServiceName("identitystore", "IdentityStore"),
-        ServiceName("imagebuilder", "imagebuilder"),
-        ServiceName("importexport", "ImportExport"),
-        ServiceName("inspector", "Inspector"),
-        ServiceName("iot-data", "IoTDataPlane"),
-        ServiceName("iot-jobs-data", "IoTJobsDataPlane"),
-        ServiceName("iot", "IoT"),
-        ServiceName("iot1click-devices", "IoT1ClickDevicesService"),
-        ServiceName("iot1click-projects", "IoT1ClickProjects"),
-        ServiceName("iotanalytics", "IoTAnalytics"),
-        ServiceName("iotdeviceadvisor", "IoTDeviceAdvisor"),
-        ServiceName("iotevents-data", "IoTEventsData"),
-        ServiceName("iotevents", "IoTEvents"),
-        ServiceName("iotfleethub", "IoTFleetHub"),
-        ServiceName("iotsecuretunneling", "IoTSecureTunneling"),
-        ServiceName("iotsitewise", "IoTSiteWise"),
-        ServiceName("iotthingsgraph", "IoTThingsGraph"),
-        ServiceName("iotwireless", "IoTWireless"),
-        ServiceName("ivs", "IVS"),
-        ServiceName("kafka", "Kafka"),
-        ServiceName("kendra", "kendra"),
-        ServiceName("kinesis-video-archived-media", "KinesisVideoArchivedMedia"),
-        ServiceName("kinesis-video-media", "KinesisVideoMedia"),
-        ServiceName("kinesis-video-signaling", "KinesisVideoSignalingChannels"),
-        ServiceName("kinesis", "Kinesis"),
-        ServiceName("kinesisanalytics", "KinesisAnalytics"),
-        ServiceName("kinesisanalyticsv2", "KinesisAnalyticsV2"),
-        ServiceName("kinesisvideo", "KinesisVideo"),
-        ServiceName("kms", "KMS"),
-        ServiceName("lakeformation", "LakeFormation"),
-        ServiceName("lambda", "Lambda"),
-        ServiceName("lex-models", "LexModelBuildingService"),
-        ServiceName("lex-runtime", "LexRuntimeService"),
-        ServiceName("lexv2-models", "LexModelsV2"),
-        ServiceName("lexv2-runtime", "LexRuntimeV2"),
-        ServiceName("license-manager", "LicenseManager"),
-        ServiceName("lightsail", "Lightsail"),
-        ServiceName("location", "LocationService"),
-        ServiceName("logs", "CloudWatchLogs"),
-        ServiceName("lookoutequipment", "LookoutEquipment"),
-        ServiceName("lookoutmetrics", "LookoutMetrics"),
-        ServiceName("lookoutvision", "LookoutforVision"),
-        ServiceName("machinelearning", "MachineLearning"),
-        ServiceName("macie", "Macie"),
-        ServiceName("macie2", "Macie2"),
-        ServiceName("managedblockchain", "ManagedBlockchain"),
-        ServiceName("marketplace-catalog", "MarketplaceCatalog"),
-        ServiceName("marketplace-entitlement", "MarketplaceEntitlementService"),
-        ServiceName("marketplacecommerceanalytics", "MarketplaceCommerceAnalytics"),
-        ServiceName("mediaconnect", "MediaConnect"),
-        ServiceName("mediaconvert", "MediaConvert"),
-        ServiceName("medialive", "MediaLive"),
-        ServiceName("mediapackage-vod", "MediaPackageVod"),
-        ServiceName("mediapackage", "MediaPackage"),
-        ServiceName("mediastore-data", "MediaStoreData"),
-        ServiceName("mediastore", "MediaStore"),
-        ServiceName("mediatailor", "MediaTailor"),
-        ServiceName("meteringmarketplace", "MarketplaceMetering"),
-        ServiceName("mgh", "MigrationHub"),
-        ServiceName("mgn", "mgn"),
-        ServiceName("migrationhub-config", "MigrationHubConfig"),
-        ServiceName("mobile", "Mobile"),
-        ServiceName("mq", "MQ"),
-        ServiceName("mturk", "MTurk"),
-        ServiceName("mwaa", "MWAA"),
-        ServiceName("neptune", "Neptune"),
-        ServiceName("network-firewall", "NetworkFirewall"),
-        ServiceName("networkmanager", "NetworkManager"),
-        ServiceName("nimble", "NimbleStudio"),
-        ServiceName("opsworks", "OpsWorks"),
-        ServiceName("opsworkscm", "OpsWorksCM"),
-        ServiceName("organizations", "Organizations"),
-        ServiceName("outposts", "Outposts"),
-        ServiceName("personalize-events", "PersonalizeEvents"),
-        ServiceName("personalize-runtime", "PersonalizeRuntime"),
-        ServiceName("personalize", "Personalize"),
-        ServiceName("pi", "PI"),
-        ServiceName("pinpoint-email", "PinpointEmail"),
-        ServiceName("pinpoint-sms-voice", "PinpointSMSVoice"),
-        ServiceName("pinpoint", "Pinpoint"),
-        ServiceName("polly", "Polly"),
-        ServiceName("pricing", "Pricing"),
-        ServiceName("proton", "Proton"),
-        ServiceName("qldb-session", "QLDBSession"),
-        ServiceName("qldb", "QLDB"),
-        ServiceName("quicksight", "QuickSight"),
-        ServiceName("ram", "RAM"),
-        ServiceName("rds-data", "RDSDataService"),
-        ServiceName("rds", "RDS"),
-        ServiceName("redshift-data", "RedshiftDataAPIService"),
-        ServiceName("redshift", "Redshift"),
-        ServiceName("rekognition", "Rekognition"),
-        ServiceName("resource-groups", "ResourceGroups"),
-        ServiceName("resourcegroupstaggingapi", "ResourceGroupsTaggingAPI"),
-        ServiceName("robomaker", "RoboMaker"),
-        ServiceName("route53", "Route53"),
-        ServiceName("route53domains", "Route53Domains"),
-        ServiceName("route53resolver", "Route53Resolver"),
-        ServiceName("s3", "S3"),
-        ServiceName("s3control", "S3Control"),
-        ServiceName("s3outposts", "S3Outposts"),
-        ServiceName("sagemaker-a2i-runtime", "AugmentedAIRuntime"),
-        ServiceName("sagemaker-edge", "SagemakerEdgeManager"),
-        ServiceName("sagemaker-featurestore-runtime", "SageMakerFeatureStoreRuntime"),
-        ServiceName("sagemaker-runtime", "SageMakerRuntime"),
-        ServiceName("sagemaker", "SageMaker"),
-        ServiceName("savingsplans", "SavingsPlans"),
-        ServiceName("schemas", "Schemas"),
-        ServiceName("sdb", "SimpleDB"),
-        ServiceName("secretsmanager", "SecretsManager"),
-        ServiceName("securityhub", "SecurityHub"),
-        ServiceName("serverlessrepo", "ServerlessApplicationRepository"),
-        ServiceName("service-quotas", "ServiceQuotas"),
-        ServiceName("servicecatalog-appregistry", "AppRegistry"),
-        ServiceName("servicecatalog", "ServiceCatalog"),
-        ServiceName("servicediscovery", "ServiceDiscovery"),
-        ServiceName("ses", "SES"),
-        ServiceName("sesv2", "SESV2"),
-        ServiceName("shield", "Shield"),
-        ServiceName("signer", "signer"),
-        ServiceName("sms-voice", "PinpointSMSVoice"),
-        ServiceName("sms", "SMS"),
-        ServiceName("snowball", "Snowball"),
-        ServiceName("sns", "SNS"),
-        ServiceName("sqs", "SQS"),
-        ServiceName("ssm-contacts", "SSMContacts"),
-        ServiceName("ssm-incidents", "SSMIncidents"),
-        ServiceName("ssm", "SSM"),
-        ServiceName("sso-admin", "SSOAdmin"),
-        ServiceName("sso-oidc", "SSOOIDC"),
-        ServiceName("sso", "SSO"),
-        ServiceName("stepfunctions", "SFN"),
-        ServiceName("storagegateway", "StorageGateway"),
-        ServiceName("sts", "STS"),
-        ServiceName("support", "Support"),
-        ServiceName("swf", "SWF"),
-        ServiceName("synthetics", "Synthetics"),
-        ServiceName("textract", "Textract"),
-        ServiceName("timestream-query", "TimestreamQuery"),
-        ServiceName("timestream-write", "TimestreamWrite"),
-        ServiceName("transcribe", "TranscribeService"),
-        ServiceName("transfer", "Transfer"),
-        ServiceName("translate", "Translate"),
-        ServiceName("waf-regional", "WAFRegional"),
-        ServiceName("waf", "WAF"),
-        ServiceName("wafv2", "WAFV2"),
-        ServiceName("wellarchitected", "WellArchitected"),
-        ServiceName("workdocs", "WorkDocs"),
-        ServiceName("worklink", "WorkLink"),
-        ServiceName("workmail", "WorkMail"),
-        ServiceName("workmailmessageflow", "WorkMailMessageFlow"),
-        ServiceName("workspaces", "WorkSpaces"),
-        ServiceName("xray", "XRay"),
-    )
-    ITEM_MAP: Mapping[str, ServiceName] = {i.name: i for i in ITEMS}
+    ec2 = ServiceName("ec2", "EC2")
+    iam = ServiceName("iam", "IAM")
+    s3 = ServiceName("s3", "S3")
+    cloudwatch = ServiceName("cloudwatch", "CloudWatch")
+    opsworks = ServiceName("opsworks", "OpsWorks")
+    sns = ServiceName("sns", "SNS")
+    glacier = ServiceName("glacier", "Glacier")
+    dynamodb = ServiceName("dynamodb", "DynamoDB")
+    sqs = ServiceName("sqs", "SQS")
+    cloudformation = ServiceName("cloudformation", "CloudFormation")
+    cloudsearchdomain = ServiceName("cloudsearchdomain", "CloudSearchDomain")
+    logs = ServiceName("logs", "CloudWatchLogs")
+    lambda_ = ServiceName("lambda", "Lambda")
 
-    ec2 = ITEM_MAP["ec2"]
-    iam = ITEM_MAP["iam"]
-    s3 = ITEM_MAP["s3"]
-    cloudwatch = ITEM_MAP["cloudwatch"]
-    opsworks = ITEM_MAP["opsworks"]
-    sns = ITEM_MAP["sns"]
-    glacier = ITEM_MAP["glacier"]
-    dynamodb = ITEM_MAP["dynamodb"]
-    sqs = ITEM_MAP["sqs"]
-    cloudformation = ITEM_MAP["cloudformation"]
-    cloudsearchdomain = ITEM_MAP["cloudsearchdomain"]
-    logs = ITEM_MAP["logs"]
-    lambda_ = ITEM_MAP["lambda"]
+    ITEMS: Dict[str, ServiceName] = {
+        ec2.name: ec2,
+        iam.name: iam,
+        s3.name: s3,
+        cloudwatch.name: cloudwatch,
+        opsworks.name: opsworks,
+        sns.name: sns,
+        glacier.name: glacier,
+        dynamodb.name: dynamodb,
+        sqs.name: sqs,
+        cloudformation.name: cloudformation,
+        cloudsearchdomain.name: cloudsearchdomain,
+        logs.name: logs,
+        lambda_.name: lambda_,
+    }
 
     @classmethod
     def find(cls, name: str) -> ServiceName:
@@ -483,7 +225,7 @@ class ServiceNameCatalog:
             ValueError -- If ServiceName not found.
         """
         try:
-            return cls.ITEM_MAP[name]
+            return cls.ITEMS[name]
         except KeyError as exc:
             raise ValueError(f"Unknown service {name}") from exc
 
@@ -494,3 +236,20 @@ class ServiceNameCatalog:
         """
         class_name = "".join([i.capitalize() for i in name.split("-")])
         return ServiceName(name, class_name)
+
+    @classmethod
+    def add(cls, name: str, class_name: str) -> ServiceName:
+        """
+        Add new ServiceName to catalog or modify existing one.
+
+        Returns:
+            New ServiceName or modified if it exists.
+        """
+        if name in cls.ITEMS:
+            service_name = cls.ITEMS[name]
+            service_name.class_name = class_name
+            return service_name
+
+        service_name = ServiceName(name, class_name)
+        cls.ITEMS[name] = service_name
+        return service_name

--- a/mypy_boto3_builder/structures/package.py
+++ b/mypy_boto3_builder/structures/package.py
@@ -1,9 +1,8 @@
 """
 Parent class for all package structures.
 """
-import logging
 
-from mypy_boto3_builder.constants import LOGGER_NAME
+from mypy_boto3_builder.logger import get_logger
 
 
 class Package:
@@ -14,4 +13,4 @@ class Package:
     def __init__(self, name: str, pypi_name: str):
         self.name = name
         self.pypi_name = pypi_name
-        self.logger = logging.getLogger(LOGGER_NAME)
+        self.logger = get_logger()

--- a/mypy_boto3_builder/templates/boto3-stubs/setup.py.jinja2
+++ b/mypy_boto3_builder/templates/boto3-stubs/setup.py.jinja2
@@ -32,7 +32,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Typing :: Typed",
     ],
-    keywords='boto3 type-annotations boto3-stubs mypy mypy-stubs typeshed autocomplete auto-generated',
+    keywords='boto3 type-annotations boto3-stubs mypy typeshed autocomplete',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     package_data={"{{ package.name }}": ["py.typed", "*.pyi", "*/*.pyi"]},
@@ -49,16 +49,16 @@ setup(
     extras_require={
         "all": [
             {% for service_name in package.service_names -%}
-            "{{ service_name.pypi_name }}=={{ build_version }}",
+            "{{ service_name.pypi_name }}>={{ min_build_version }}",
             {% endfor -%}
         ],
         "essential": [
             {% for service_name in package.essential_service_names -%}
-            "{{ service_name.pypi_name }}=={{ build_version }}",
+            "{{ service_name.pypi_name }}>={{ min_build_version }}",
             {% endfor -%}
         ],
         {% for service_name in package.service_names -%}
-        "{{ service_name.extras_name }}": ["{{ service_name.pypi_name }}=={{ build_version }}"],
+        "{{ service_name.extras_name }}": ["{{ service_name.pypi_name }}>={{ min_build_version }}"],
         {% endfor -%}
     },
     zip_safe=False,

--- a/mypy_boto3_builder/templates/botocore-stubs/setup.py.jinja2
+++ b/mypy_boto3_builder/templates/botocore-stubs/setup.py.jinja2
@@ -32,7 +32,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Typing :: Typed",
     ],
-    keywords='boto3 type-annotations boto3-stubs mypy mypy-stubs typeshed autocomplete auto-generated',
+    keywords='boto3 type-annotations botocore-stubs mypy typeshed autocomplete',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     package_data={"botocore-stubs": ["py.typed", "*.pyi", "*/*.pyi"]},

--- a/mypy_boto3_builder/templates/service/setup.py.jinja2
+++ b/mypy_boto3_builder/templates/service/setup.py.jinja2
@@ -32,7 +32,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Typing :: Typed",
     ],
-    keywords='boto3 {{ service_name.boto3_name }} type-annotations boto3-stubs mypy typeshed autocomplete auto-generated',
+    keywords='boto3 {{ service_name.boto3_name }} type-annotations boto3-stubs mypy typeshed autocomplete',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     package_data={"{{ service_name.module_name }}": ["py.typed", "*.pyi"]},

--- a/mypy_boto3_builder/utils/nice_path.py
+++ b/mypy_boto3_builder/utils/nice_path.py
@@ -34,9 +34,12 @@ class NicePath(type(Path())):  # type: ignore
         Yields:
             Existing Path.
         """
+        exclude_strs = {NicePath(i).as_posix() for i in exclude}
         for path in self.glob("**/*"):
             if not path.is_file():
                 continue
 
-            if path not in exclude:
-                yield path
+            if path.as_posix() in exclude_strs:
+                continue
+
+            yield path

--- a/mypy_boto3_builder/utils/nice_path.py
+++ b/mypy_boto3_builder/utils/nice_path.py
@@ -2,6 +2,7 @@
 Path that represents it as relative to workdir.
 """
 from pathlib import Path
+from typing import Iterable, Iterator
 
 
 class NicePath(type(Path())):  # type: ignore
@@ -17,7 +18,7 @@ class NicePath(type(Path())):  # type: ignore
                 return str(path)
 
             try:
-                path = Path(self.relative_to(cwd))
+                path = Path(self).relative_to(cwd)
             except ValueError:
                 return str(path)
 
@@ -25,3 +26,17 @@ class NicePath(type(Path())):  # type: ignore
             return f"./{path}"
 
         return str(path)
+
+    def walk(self, exclude: Iterable[Path] = tuple()) -> Iterator[Path]:
+        """
+        Walk files except for `exclude`.
+
+        Yields:
+            Existing Path.
+        """
+        for path in self.glob("**/*"):
+            if not path.is_file():
+                continue
+
+            if path not in exclude:
+                yield path

--- a/mypy_boto3_builder/utils/strings.py
+++ b/mypy_boto3_builder/utils/strings.py
@@ -5,7 +5,7 @@ import builtins
 import keyword
 import textwrap
 import typing
-from typing import List
+from typing import Dict, List
 
 RESERVED_NAMES = set(
     (
@@ -139,3 +139,21 @@ def get_short_docstring(doc: str) -> str:
         result_str = f"{result_str}."
 
     return "\n".join(textwrap.wrap(result_str, width=80))
+
+
+def get_botocore_class_name(metadata: Dict[str, str]) -> str:
+    """
+    Get Botocore class name from Service metadata.
+    """
+    class_name = metadata["serviceId"]
+    if "serviceFullName" in metadata:
+        class_name = metadata["serviceFullName"]
+    if "serviceAbbreviation" in metadata:
+        class_name = metadata["serviceAbbreviation"]
+
+    class_name = class_name.replace(" ", "").replace("-", "").replace("/", "")
+    if class_name.startswith("AWS"):
+        class_name = class_name[3:]
+    if class_name.startswith("Amazon"):
+        class_name = class_name[6:]
+    return class_name

--- a/mypy_boto3_builder/utils/strings.py
+++ b/mypy_boto3_builder/utils/strings.py
@@ -157,3 +157,18 @@ def get_botocore_class_name(metadata: Dict[str, str]) -> str:
     if class_name.startswith("Amazon"):
         class_name = class_name[6:]
     return class_name
+
+
+def get_min_build_version(version: str) -> str:
+    """
+    Get min version 5 micro releases lower that `version`.
+
+    Minimum micro is 0.
+    """
+    major = minor = micro = "0"
+    if version.count(".") > 2:
+        major, minor, micro, _ = version.split(".", 3)
+    else:
+        major, minor, micro = version.split(".", 2)
+    new_micro = max(int(micro) - 5, 0)
+    return f"{major}.{minor}.{new_micro}"

--- a/mypy_boto3_builder/writers/boto3_stubs_package.py
+++ b/mypy_boto3_builder/writers/boto3_stubs_package.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import List, Tuple
 
 from mypy_boto3_builder.constants import BOTO3_STUBS_STATIC_PATH
+from mypy_boto3_builder.logger import get_logger
 from mypy_boto3_builder.structures.boto3_stubs_package import Boto3StubsPackage
 from mypy_boto3_builder.utils.markdown import fix_pypi_headers
+from mypy_boto3_builder.utils.nice_path import NicePath
 from mypy_boto3_builder.writers.utils import (
     blackify,
     format_md,
@@ -20,24 +22,20 @@ from mypy_boto3_builder.writers.utils import (
 
 def write_boto3_stubs_package(
     package: Boto3StubsPackage, output_path: Path, generate_setup: bool
-) -> List[Path]:
+) -> None:
     """
     Generate stubs for boto3-stubs package.
     """
+    logger = get_logger()
     setup_path = output_path / "boto3_stubs_package"
     if not generate_setup:
         setup_path = output_path
 
-    modified_paths: List[Path] = []
     package_path = setup_path / package.name
     if not generate_setup:
         package_path = setup_path / "boto3"
 
-    if setup_path.exists():
-        shutil.rmtree(setup_path)
-
-    setup_path.mkdir(exist_ok=True)
-    package_path.mkdir(exist_ok=True)
+    package_path.mkdir(exist_ok=True, parents=True)
 
     templates_path = Path("boto3-stubs")
     module_templates_path = templates_path / "boto3-stubs"
@@ -76,10 +74,11 @@ def write_boto3_stubs_package(
             content = fix_pypi_headers(content)
             content = format_md(content)
         if not file_path.exists() or file_path.read_text() != content:
-            modified_paths.append(file_path)
             file_path.write_text(content)
+            logger.debug(f"Updated {NicePath(file_path)}")
 
-    for static_path in BOTO3_STUBS_STATIC_PATH.glob("**/*.pyi"):
+    static_paths = BOTO3_STUBS_STATIC_PATH.glob("**/*.pyi")
+    for static_path in static_paths:
         relative_output_path = static_path.relative_to(BOTO3_STUBS_STATIC_PATH)
         file_path = package_path / relative_output_path
         file_path.parent.mkdir(exist_ok=True)
@@ -87,15 +86,19 @@ def write_boto3_stubs_package(
             continue
 
         shutil.copy(static_path, file_path)
-        modified_paths.append(file_path)
+        logger.debug(f"Updated {NicePath(file_path)}")
 
-    return modified_paths
+    valid_paths = (*dict(file_paths).keys(), *static_paths)
+    for unknown_path in NicePath(package_path).walk(valid_paths):
+        unknown_path.unlink()
+        logger.debug(f"Deleted {NicePath(unknown_path)}")
 
 
-def write_boto3_stubs_docs(package: Boto3StubsPackage, output_path: Path) -> List[Path]:
+def write_boto3_stubs_docs(package: Boto3StubsPackage, output_path: Path) -> None:
     """
     Generate docs for boto3-stubs package.
     """
+    logger = get_logger()
     modified_paths = []
     docs_path = output_path
     docs_path.mkdir(exist_ok=True)
@@ -114,4 +117,7 @@ def write_boto3_stubs_docs(package: Boto3StubsPackage, output_path: Path) -> Lis
             modified_paths.append(file_path)
             file_path.write_text(content)
 
-    return modified_paths
+    valid_paths = dict(file_paths).keys()
+    for unknown_path in NicePath(docs_path).walk(valid_paths):
+        unknown_path.unlink()
+        logger.debug(f"Deleted {NicePath(unknown_path)}")

--- a/mypy_boto3_builder/writers/boto3_stubs_package.py
+++ b/mypy_boto3_builder/writers/boto3_stubs_package.py
@@ -73,10 +73,11 @@ def write_boto3_stubs_package(
             file_path.write_text(content)
             logger.debug(f"Updated {NicePath(file_path)}")
 
-    static_paths = BOTO3_STUBS_STATIC_PATH.glob("**/*.pyi")
-    for static_path in static_paths:
+    static_paths = []
+    for static_path in BOTO3_STUBS_STATIC_PATH.glob("**/*.pyi"):
         relative_output_path = static_path.relative_to(BOTO3_STUBS_STATIC_PATH)
         file_path = package_path / relative_output_path
+        static_paths.append(file_path)
         file_path.parent.mkdir(exist_ok=True)
         content = static_path.read_text()
         if not file_path.exists() or file_path.read_text() != content:

--- a/mypy_boto3_builder/writers/botocore_stubs_package.py
+++ b/mypy_boto3_builder/writers/botocore_stubs_package.py
@@ -70,10 +70,11 @@ def write_botocore_stubs_package(output_path: Path, generate_setup: bool) -> Non
             file_path.write_text(content)
             logger.debug(f"Updated {NicePath(file_path)}")
 
-    static_paths = BOTOCORE_STUBS_STATIC_PATH.glob("**/*.pyi")
-    for static_path in static_paths:
+    static_paths = []
+    for static_path in BOTOCORE_STUBS_STATIC_PATH.glob("**/*.pyi"):
         relative_output_path = static_path.relative_to(BOTOCORE_STUBS_STATIC_PATH)
         file_path = package_path / relative_output_path
+        static_paths.append(file_path)
         file_path.parent.mkdir(exist_ok=True)
         content = static_path.read_text()
         if not file_path.exists() or file_path.read_text() != content:

--- a/mypy_boto3_builder/writers/master_package.py
+++ b/mypy_boto3_builder/writers/master_package.py
@@ -28,10 +28,10 @@ def write_master_package(package: MasterPackage, output_path: Path, generate_set
     """
     logger = get_logger()
     setup_path = output_path / "master_package"
-    if not generate_setup:
-        setup_path = output_path
-
-    package_path = setup_path / package.name
+    if generate_setup:
+        package_path = setup_path / package.name
+    else:
+        package_path = output_path / package.name
 
     package_path.mkdir(exist_ok=True, parents=True)
 
@@ -90,6 +90,6 @@ def write_master_package(package: MasterPackage, output_path: Path, generate_set
             logger.debug(f"Updated {NicePath(file_path)}")
 
     valid_paths = dict(file_paths).keys()
-    for unknown_path in NicePath(package_path).walk(valid_paths):
+    for unknown_path in NicePath(setup_path if generate_setup else package_path).walk(valid_paths):
         unknown_path.unlink()
         logger.debug(f"Deleted {NicePath(unknown_path)}")

--- a/mypy_boto3_builder/writers/processors.py
+++ b/mypy_boto3_builder/writers/processors.py
@@ -47,12 +47,7 @@ def process_boto3_stubs(
     boto3_stubs_package = parse_boto3_stubs_package(session=session, service_names=service_names)
     logger.debug(f"Writing boto3 stubs to {NicePath(output_path)}")
 
-    modified_paths = write_boto3_stubs_package(
-        boto3_stubs_package, output_path, generate_setup=generate_setup
-    )
-    for modified_path in modified_paths:
-        logger.debug(f"Updated {NicePath(modified_path)}")
-
+    write_boto3_stubs_package(boto3_stubs_package, output_path, generate_setup=generate_setup)
     return boto3_stubs_package
 
 
@@ -70,9 +65,7 @@ def process_botocore_stubs(
     logger = get_logger()
     logger.debug(f"Writing botocore stubs to {NicePath(output_path)}")
 
-    modified_paths = write_botocore_stubs_package(output_path, generate_setup=generate_setup)
-    for modified_path in modified_paths:
-        logger.debug(f"Updated {NicePath(modified_path)}")
+    write_botocore_stubs_package(output_path, generate_setup=generate_setup)
 
 
 def process_master(
@@ -98,12 +91,7 @@ def process_master(
     master_package = parse_master_package(session, service_names)
     logger.debug(f"Writing master to {NicePath(output_path)}")
 
-    modified_paths = write_master_package(
-        master_package, output_path=output_path, generate_setup=generate_setup
-    )
-    for modified_path in modified_paths:
-        logger.debug(f"Updated {NicePath(modified_path)}")
-
+    write_master_package(master_package, output_path=output_path, generate_setup=generate_setup)
     return master_package
 
 
@@ -132,12 +120,7 @@ def process_service(
         typed_dict.replace_self_references()
     logger.debug(f"Writing {service_name.boto3_name} to {NicePath(output_path)}")
 
-    modified_paths = write_service_package(
-        service_module, output_path=output_path, generate_setup=generate_setup
-    )
-    for modified_path in modified_paths:
-        logger.debug(f"Updated {NicePath(modified_path)}")
-
+    write_service_package(service_module, output_path=output_path, generate_setup=generate_setup)
     return service_module
 
 
@@ -190,8 +173,5 @@ def process_boto3_stubs_docs(
     boto3_stubs_package = parse_boto3_stubs_package(session=session, service_names=service_names)
     logger.debug(f"Writing boto3 stubs to {NicePath(output_path)}")
 
-    modified_paths = write_boto3_stubs_docs(boto3_stubs_package, output_path=output_path)
-    for modified_path in modified_paths:
-        logger.debug(f"Updated {NicePath(modified_path)}")
-
+    write_boto3_stubs_docs(boto3_stubs_package, output_path=output_path)
     return boto3_stubs_package

--- a/mypy_boto3_builder/writers/processors.py
+++ b/mypy_boto3_builder/writers/processors.py
@@ -145,10 +145,7 @@ def process_service_docs(
     service_module = parse_service_package(session, service_name)
     logger.debug(f"Writing {service_name.boto3_name} to {NicePath(output_path)}")
 
-    modified_paths = write_service_docs(service_module, output_path=output_path)
-    for modified_path in modified_paths:
-        logger.debug(f"Updated {NicePath(modified_path)}")
-
+    write_service_docs(service_module, output_path=output_path)
     return service_module
 
 
@@ -170,7 +167,7 @@ def process_boto3_stubs_docs(
     """
     logger = get_logger()
     logger.debug("Parsing boto3 stubs")
-    boto3_stubs_package = parse_boto3_stubs_package(session=session, service_names=service_names)
+    boto3_stubs_package = parse_boto3_stubs_package(session, service_names)
     logger.debug(f"Writing boto3 stubs to {NicePath(output_path)}")
 
     write_boto3_stubs_docs(boto3_stubs_package, output_path=output_path)

--- a/mypy_boto3_builder/writers/service_package.py
+++ b/mypy_boto3_builder/writers/service_package.py
@@ -1,13 +1,14 @@
 """
 Service package writer.
 """
-import shutil
 from pathlib import Path
 from typing import List, Tuple
 
 from mypy_boto3_builder.enums.service_module_name import ServiceModuleName
+from mypy_boto3_builder.logger import get_logger
 from mypy_boto3_builder.structures.service_package import ServicePackage
 from mypy_boto3_builder.utils.markdown import fix_pypi_headers
+from mypy_boto3_builder.utils.nice_path import NicePath
 from mypy_boto3_builder.writers.utils import (
     blackify,
     format_md,
@@ -17,9 +18,7 @@ from mypy_boto3_builder.writers.utils import (
 )
 
 
-def write_service_package(
-    package: ServicePackage, output_path: Path, generate_setup: bool
-) -> List[Path]:
+def write_service_package(package: ServicePackage, output_path: Path, generate_setup: bool) -> None:
     """
     Create stubs files for service.
 
@@ -28,18 +27,13 @@ def write_service_package(
         output_path -- Path to output folder.
         generate_setup -- Generate ready-to-install or to-use package.
     """
+    logger = get_logger()
     setup_path = output_path / f"{package.service_name.module_name}_package"
     if not generate_setup:
         setup_path = output_path
 
-    modified_paths: List[Path] = []
     package_path = setup_path / package.name
-
-    if setup_path.exists():
-        shutil.rmtree(setup_path)
-
-    setup_path.mkdir(exist_ok=True)
-    package_path.mkdir(exist_ok=True)
+    package_path.mkdir(exist_ok=True, parents=True)
 
     templates_path = Path("service")
     module_templates_path = templates_path / "service"
@@ -149,10 +143,13 @@ def write_service_package(
             content = format_md(content)
 
         if not file_path.exists() or file_path.read_text() != content:
-            modified_paths.append(file_path)
             file_path.write_text(content)
+            logger.debug(f"Updated {NicePath(file_path)}")
 
-    return modified_paths
+    valid_paths = dict(file_paths).keys()
+    for unknown_path in NicePath(package_path).walk(valid_paths):
+        unknown_path.unlink()
+        logger.debug(f"Deleted {NicePath(unknown_path)}")
 
 
 def write_service_docs(package: ServicePackage, output_path: Path) -> List[Path]:

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,20 +65,20 @@ webencodings = "*"
 
 [[package]]
 name = "boto3"
-version = "1.17.103"
+version = "1.17.107"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
-botocore = ">=1.20.103,<1.21.0"
+botocore = ">=1.20.107,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.4.0,<0.5.0"
 
 [[package]]
 name = "botocore"
-version = "1.20.103"
+version = "1.20.107"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -234,7 +234,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.6.0"
+version = "4.6.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -258,7 +258,7 @@ python-versions = "*"
 
 [[package]]
 name = "isort"
-version = "5.9.1"
+version = "5.9.2"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = false
@@ -395,11 +395,11 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "20.9"
+version = "21.0"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -571,7 +571,7 @@ md = ["cmarkgfm (>=0.5.0,<0.6.0)"]
 
 [[package]]
 name = "regex"
-version = "2021.4.4"
+version = "2021.7.6"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
@@ -669,11 +669,14 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tqdm"
-version = "4.61.1"
+version = "4.61.2"
 description = "Fast, Extensible Progress Meter"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "wheel"]
@@ -773,7 +776,7 @@ python-versions = "*"
 
 [[package]]
 name = "zipp"
-version = "3.4.1"
+version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -781,7 +784,7 @@ python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
@@ -810,12 +813,12 @@ bleach = [
     {file = "bleach-3.3.0.tar.gz", hash = "sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433"},
 ]
 boto3 = [
-    {file = "boto3-1.17.103-py2.py3-none-any.whl", hash = "sha256:5de0db8433acc06c1b6811899587d65997fb4031f54506e63716c9e188b4ff3c"},
-    {file = "boto3-1.17.103.tar.gz", hash = "sha256:b50067fc63c519387fc3ec46c05a78e5c7e25c1a1ec0d07a40103c4a47544fd4"},
+    {file = "boto3-1.17.107-py2.py3-none-any.whl", hash = "sha256:ca911509477d499b62029aaef01ba042ec0fd214f372773a4d8566a7cd422d91"},
+    {file = "boto3-1.17.107.tar.gz", hash = "sha256:4a6febc5ab709b2c53a72ebb420e4be29e84a01a0f84604e8b5dc43e8d1bfab0"},
 ]
 botocore = [
-    {file = "botocore-1.20.103-py2.py3-none-any.whl", hash = "sha256:5b39773056a94f85e884a658a5126bb4fee957e31d98b69c255b137eb9f11d6b"},
-    {file = "botocore-1.20.103.tar.gz", hash = "sha256:afbfe10fcd580224016d652330db21e7d89099181a437c9ec588b5b7cb3ea644"},
+    {file = "botocore-1.20.107-py2.py3-none-any.whl", hash = "sha256:bfd08ae511ed27095ce4cb9c3bba953909a02d62114e7560cb4bdfa045747e54"},
+    {file = "botocore-1.20.107.tar.gz", hash = "sha256:59539432640d1b0324c375b906f1e3a37935b4e589c133cd7f50490be7ab7986"},
 ]
 certifi = [
     {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
@@ -966,16 +969,16 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.6.0-py3-none-any.whl", hash = "sha256:c6513572926a96458f8c8f725bf0e00108fba0c9583ade9bd15b869c9d726e33"},
-    {file = "importlib_metadata-4.6.0.tar.gz", hash = "sha256:4a5611fea3768d3d967c447ab4e93f567d95db92225b43b7b238dbfb855d70bb"},
+    {file = "importlib_metadata-4.6.1-py3-none-any.whl", hash = "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"},
+    {file = "importlib_metadata-4.6.1.tar.gz", hash = "sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
-    {file = "isort-5.9.1-py3-none-any.whl", hash = "sha256:8e2c107091cfec7286bc0f68a547d0ba4c094d460b732075b6fba674f1035c0c"},
-    {file = "isort-5.9.1.tar.gz", hash = "sha256:83510593e07e433b77bd5bff0f6f607dbafa06d1a89022616f02d8b699cfcd56"},
+    {file = "isort-5.9.2-py3-none-any.whl", hash = "sha256:eed17b53c3e7912425579853d078a0832820f023191561fcee9d7cae424e0813"},
+    {file = "isort-5.9.2.tar.gz", hash = "sha256:f65ce5bd4cbc6abdfbe29afc2f0245538ab358c14590912df638033f157d555e"},
 ]
 jeepney = [
     {file = "jeepney-0.6.0-py3-none-any.whl", hash = "sha256:aec56c0eb1691a841795111e184e13cad504f7703b9a64f63020816afa79a8ae"},
@@ -1071,8 +1074,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
-    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
+    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
@@ -1135,47 +1138,47 @@ readme-renderer = [
     {file = "readme_renderer-29.0.tar.gz", hash = "sha256:92fd5ac2bf8677f310f3303aa4bce5b9d5f9f2094ab98c29f13791d7b805a3db"},
 ]
 regex = [
-    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
-    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
-    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
-    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
-    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
-    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
-    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
-    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
-    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
-    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
-    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
-    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
-    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
+    {file = "regex-2021.7.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407"},
+    {file = "regex-2021.7.6-cp36-cp36m-win32.whl", hash = "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b"},
+    {file = "regex-2021.7.6-cp36-cp36m-win_amd64.whl", hash = "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb"},
+    {file = "regex-2021.7.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895"},
+    {file = "regex-2021.7.6-cp37-cp37m-win32.whl", hash = "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5"},
+    {file = "regex-2021.7.6-cp37-cp37m-win_amd64.whl", hash = "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f"},
+    {file = "regex-2021.7.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux1_i686.whl", hash = "sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068"},
+    {file = "regex-2021.7.6-cp38-cp38-win32.whl", hash = "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0"},
+    {file = "regex-2021.7.6-cp38-cp38-win_amd64.whl", hash = "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4"},
+    {file = "regex-2021.7.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3"},
+    {file = "regex-2021.7.6-cp39-cp39-win32.whl", hash = "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035"},
+    {file = "regex-2021.7.6-cp39-cp39-win_amd64.whl", hash = "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c"},
+    {file = "regex-2021.7.6.tar.gz", hash = "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d"},
 ]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
@@ -1210,8 +1213,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tqdm = [
-    {file = "tqdm-4.61.1-py2.py3-none-any.whl", hash = "sha256:aa0c29f03f298951ac6318f7c8ce584e48fa22ec26396e6411e43d038243bdb2"},
-    {file = "tqdm-4.61.1.tar.gz", hash = "sha256:24be966933e942be5f074c29755a95b315c69a91f839a29139bf26ffffe2d3fd"},
+    {file = "tqdm-4.61.2-py2.py3-none-any.whl", hash = "sha256:5aa445ea0ad8b16d82b15ab342de6b195a722d75fc1ef9934a46bba6feafbc64"},
+    {file = "tqdm-4.61.2.tar.gz", hash = "sha256:8bb94db0d4468fea27d004a0f1d1c02da3cdedc00fe491c0de986b76a04d6b0a"},
 ]
 twine = [
     {file = "twine-3.4.1-py3-none-any.whl", hash = "sha256:16f706f2f1687d7ce30e7effceee40ed0a09b7c33b9abb5ef6434e5551565d83"},
@@ -1279,6 +1282,6 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 zipp = [
-    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
-    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
+    {file = "zipp-3.5.0-py3-none-any.whl", hash = "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3"},
+    {file = "zipp-3.5.0.tar.gz", hash = "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"},
 ]

--- a/scripts/check_output.py
+++ b/scripts/check_output.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
+"""
+Checker of generated packages.
+
+- [x] import generated package
+- [x] flake8
+- [x] pyright
+- [ ] mypy
+"""
 import argparse
-import difflib
 import json
 import logging
 import subprocess
@@ -10,7 +17,7 @@ from pathlib import Path
 
 ROOT_PATH = Path(__file__).parent.parent.resolve()
 LOGGER_NAME = "check_output"
-IGNORE_ERRORS = (
+IGNORE_PYLINT_ERRORS = (
     '"get_paginator" is marked as overload, but no implementation is provided',
     '"get_waiter" is marked as overload, but no implementation is provided',
     # 'Expected type arguments for generic class "ResourceCollection"',
@@ -21,10 +28,16 @@ IGNORE_ERRORS = (
     'Method "paginate" overrides class "Paginator" in an incompatible manner',
     'Method "wait" overrides class "Waiter" in an incompatible manner',
 )
+IGNORE_MYPY_ERRORS = (
+    'Signature of "paginate" incompatible with supertype "Paginator"',
+    'Signature of "wait" incompatible with supertype "Waiter"',
+)
 
 
 class SnapshotMismatchError(Exception):
-    pass
+    """
+    Main snapshot mismatch exception.
+    """
 
 
 def setup_logging(level: int = 0) -> logging.Logger:
@@ -49,39 +62,19 @@ def setup_logging(level: int = 0) -> logging.Logger:
 
 
 def parse_args() -> argparse.Namespace:
+    """
+    Setup CLI parser.
+    """
     parser = argparse.ArgumentParser(__file__)
     parser.add_argument("-p", "--path", type=Path, default=ROOT_PATH / "mypy_boto3_output")
     parser.add_argument("services", nargs="*")
     return parser.parse_args()
 
 
-def compare(data: str, snapshot_path: Path, update: bool) -> None:
-    data = data.strip()
-    logger = logging.getLogger(LOGGER_NAME)
-    if not snapshot_path.exists():
-        snapshot_path.write_text(data)
-        logger.info(f"Created {snapshot_path}")
-        return
-
-    old_data = snapshot_path.read_text().strip()
-    if old_data == data:
-        logger.info(f"Matched {snapshot_path}")
-        return
-
-    if update:
-        snapshot_path.write_text(data)
-        logger.info(f"Updated {snapshot_path}")
-        return
-
-    diff = difflib.unified_diff(
-        old_data.strip().splitlines(), data.strip().splitlines(), lineterm=""
-    )
-    for line in diff:
-        logger.warning(line)
-    raise SnapshotMismatchError(f"Snapshot {snapshot_path} is different")
-
-
 def run_flake8(path: Path) -> None:
+    """
+    Check output with flake8.
+    """
     with tempfile.NamedTemporaryFile("w+b") as f:
         try:
             subprocess.check_call(
@@ -103,6 +96,9 @@ def run_flake8(path: Path) -> None:
 
 
 def run_pyright(path: Path) -> None:
+    """
+    Check output with pyright.
+    """
     with tempfile.NamedTemporaryFile("w+b") as f:
         try:
             subprocess.check_call(
@@ -121,13 +117,18 @@ def run_pyright(path: Path) -> None:
         errors = []
         for error in data:
             message = error.get("message", "")
-            if any(imsg in message for imsg in IGNORE_ERRORS):
+            if any(imsg in message for imsg in IGNORE_PYLINT_ERRORS):
                 continue
             errors.append(error)
-            raise SnapshotMismatchError(error)
+
+        if errors:
+            raise SnapshotMismatchError("\n".join(errors))
 
 
 def run_mypy(path: Path) -> None:
+    """
+    Check output with mypy.
+    """
     try:
         output = subprocess.check_output(
             ["python", "-m", "mypy", path.as_posix()],
@@ -136,11 +137,32 @@ def run_mypy(path: Path) -> None:
         )
     except subprocess.CalledProcessError as e:
         output = e.output
-        raise SnapshotMismatchError(output)
-    print(output)
+        errors = []
+        for message in output.splitlines():
+            if not message or message.startswith("Found"):
+                continue
+            if any(imsg in message for imsg in IGNORE_MYPY_ERRORS):
+                continue
+            errors.append(message)
+
+        if errors:
+            raise SnapshotMismatchError("\n".join(errors)) from None
+
+
+def run_call(path: Path) -> None:
+    """
+    Check output by importing it.
+    """
+    try:
+        subprocess.check_call(["python", path.as_posix()], stdout=subprocess.DEVNULL)
+    except subprocess.CalledProcessError as e:
+        raise SnapshotMismatchError(f"Path {path} cannot be imported: {e}") from None
 
 
 def main() -> None:
+    """
+    Main CLI entrypoint.
+    """
     args = parse_args()
     setup_logging(logging.INFO)
     logger = logging.getLogger(LOGGER_NAME)
@@ -155,12 +177,15 @@ def main() -> None:
             if args.services:
                 if not any(s in package.name for s in args.services):
                     continue
+            logger.info(f"Checking {package.name} ...")
             try:
-                # logger.info(f"Running mypy for {package.name} ...")
-                # run_mypy(package)
-                logger.info(f"Running flake8 for {package.name} ...")
+                logger.debug(f"Running call for {package.name} ...")
+                run_call(package)
+                logger.debug(f"Running mypy for {package.name} ...")
+                run_mypy(package)
+                logger.debug(f"Running flake8 for {package.name} ...")
                 run_flake8(package)
-                logger.info(f"Running pyright for {package.name} ...")
+                logger.debug(f"Running pyright for {package.name} ...")
                 run_pyright(package)
             except SnapshotMismatchError as e:
                 logger.error(e)

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from mypy_boto3_builder.cli_parser import get_absolute_path, get_service_name, parse_args
+from mypy_boto3_builder.cli_parser import get_absolute_path, parse_args
 
 
 class TestCLIParser:
@@ -14,13 +14,3 @@ class TestCLIParser:
         result = get_absolute_path("test/output")
         PathMock.assert_called_with("test/output")
         assert result == PathMock().absolute()
-
-    @patch("mypy_boto3_builder.cli_parser.ServiceNameCatalog")
-    def test_get_service_name(self, ServiceNameCatalogMock: MagicMock) -> None:
-        result = get_service_name("name")
-        ServiceNameCatalogMock.find.assert_called_with("name")
-        assert result == ServiceNameCatalogMock.find()
-
-        ServiceNameCatalogMock.find.side_effect = ValueError()
-        assert get_service_name("name") == ServiceNameCatalogMock.create()
-        assert get_service_name("name-none") == ServiceNameCatalogMock.create()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ class TestMain:
     def test_get_available_service_names(self) -> None:
         session_mock = MagicMock()
         session_mock.get_available_services.return_value = ["s3", "ec2", "unsupported"]
-        assert len(get_available_service_names(session_mock)) == 2
+        assert len(get_available_service_names(session_mock)) == 3
 
     @patch("mypy_boto3_builder.main.generate_stubs")
     @patch("mypy_boto3_builder.main.generate_docs")
@@ -30,16 +30,17 @@ class TestMain:
             namespace = Namespace(
                 log_level=0,
                 output_path=Path(output_dir),
-                service_names=[ServiceName("s3", "S3")],
+                service_names=["s3"],
                 build_version="1.2.3.post4",
                 installed=False,
                 skip_master=False,
                 skip_services=False,
                 builder_version="1.2.3",
                 generate_docs=False,
+                list_services=False,
             )
             session_mock = MagicMock()
-            generate_docs(namespace, service_names=namespace.service_names, session=session_mock)
+            generate_docs(namespace, service_names=[ServiceName("s3", "S3")], session=session_mock)
             process_boto3_stubs_docs_mock.assert_called()
             process_service_docs_mock.assert_called()
 
@@ -58,16 +59,17 @@ class TestMain:
             namespace = Namespace(
                 log_level=0,
                 output_path=Path(output_dir),
-                service_names=[ServiceName("s3", "S3")],
+                service_names=["s3"],
                 build_version="1.2.3.post4",
                 installed=False,
                 skip_master=False,
                 skip_services=False,
                 builder_version="1.2.3",
                 generate_docs=False,
+                list_services=False,
             )
             session_mock = MagicMock()
-            generate_stubs(namespace, service_names=namespace.service_names, session=session_mock)
+            generate_stubs(namespace, service_names=[ServiceName("s3", "S3")], session=session_mock)
             process_botocore_stubs_mock.assert_called()
             process_boto3_stubs_mock.assert_called()
             process_master_mock.assert_called()

--- a/tests/type_annotations/test_type_typed_dict.py
+++ b/tests/type_annotations/test_type_typed_dict.py
@@ -48,6 +48,10 @@ class TestTypeTypedDict:
         assert self.result.render() == "MyDict"
         assert self.result.render("OtherDict") == "MyDict"
         assert self.result.render("MyDict") == '"MyDict"'
+        self.result.stringify = True
+        assert self.result.render() == '"MyDict"'
+        self.result.replace_with_dict.add(self.result.name)
+        assert self.result.render("MyDict") == "Dict[str, Any]"
 
     def test_get_import_record(self) -> None:
         assert self.result.get_import_record().render() == "from .type_defs import MyDict"
@@ -61,6 +65,9 @@ class TestTypeTypedDict:
 
     def test_is_dict(self) -> None:
         assert self.result.is_dict()
+
+    def test_is_typed_dict(self) -> None:
+        assert self.result.is_typed_dict()
 
     def test_render_class(self) -> None:
         assert self.result.render_class() == "class MyDict:\n    required: bool\n    optional: str"
@@ -140,6 +147,7 @@ class TestTypeTypedDict:
 
     def test_get_children_literals(self) -> None:
         assert len(self.result.get_children_literals()) == 0
+        assert len(self.result.get_children_literals([self.result])) == 0
 
     def test_replace_self_references(self) -> None:
         self.result.replace_self_references()

--- a/tests/type_maps/test_literal_type_map.py
+++ b/tests/type_maps/test_literal_type_map.py
@@ -1,0 +1,13 @@
+from mypy_boto3_builder.service_name import ServiceNameCatalog
+from mypy_boto3_builder.type_maps.literal_type_map import ResourceStatusType, get_literal_type_stub
+
+
+def test_get_literal_type_stub() -> None:
+    assert (
+        get_literal_type_stub(ServiceNameCatalog.cloudformation, "ResourceStatusType")
+        is ResourceStatusType
+    )
+    assert get_literal_type_stub(ServiceNameCatalog.ec2, "ResourceStatusType") is None
+    assert (
+        get_literal_type_stub(ServiceNameCatalog.cloudformation, "NoneResourceStatusType") is None
+    )

--- a/tests/utils/test_markdown.py
+++ b/tests/utils/test_markdown.py
@@ -1,4 +1,16 @@
-from mypy_boto3_builder.utils.markdown import fix_pypi_headers
+from mypy_boto3_builder.utils.markdown import Header, TableOfContents, fix_pypi_headers
+
+
+class TestTableOfContents:
+    def test_render(self) -> None:
+        toc = TableOfContents(
+            [
+                Header("a", 1),
+                Header("b", 3),
+                Header("c", 6),
+            ]
+        )
+        assert toc.render() == "- [a](#a)\n    - [b](#b)"
 
 
 class TestMarkdown:
@@ -7,4 +19,4 @@ class TestMarkdown:
             fix_pypi_headers("# a\ntest\n## b\n## c\ntest2")
             == '<a id="a"></a>\n\n# a\ntest\n<a id="b"></a>\n\n## b\n<a id="c"></a>\n\n## c\ntest2'
         )
-        assert fix_pypi_headers("# a\n") == '<a id="a"></a>\n\n# a'
+        assert fix_pypi_headers("# a\n```## b```") == '<a id="a"></a>\n\n# a\n```## b```'

--- a/tests/utils/test_nice_path.py
+++ b/tests/utils/test_nice_path.py
@@ -1,3 +1,4 @@
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,3 +15,14 @@ class TestNicePath:
             assert str(NicePath("/absolute")) == "/absolute"
             assert str(NicePath("/")) == "/"
             assert str(NicePath(".")) == "."
+
+    def test_walk(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_path = NicePath(output_dir)
+            (output_path / "one.txt").touch()
+            (output_path / "two.txt").touch()
+            result = list(output_path.walk())
+            assert len(result) == 2
+            result = list(output_path.walk([output_path / "one.txt"]))
+            assert len(result) == 1
+            assert result[0] == output_path / "two.txt"

--- a/tests/utils/test_strings.py
+++ b/tests/utils/test_strings.py
@@ -2,6 +2,7 @@ from mypy_boto3_builder.utils.strings import (
     get_anchor_link,
     get_class_prefix,
     get_line_with_indented,
+    get_min_build_version,
     get_short_docstring,
     is_reserved,
 )
@@ -51,3 +52,9 @@ class TestStrings:
             )
             == "This action aborts a multipart upload."
         )
+
+    def test_get_min_build_version(self):
+        assert get_min_build_version("1.22.36") == "1.22.31"
+        assert get_min_build_version("1.22.48.post13") == "1.22.43"
+        assert get_min_build_version("1.13.3") == "1.13.0"
+        assert get_min_build_version("1.13.2.post56") == "1.13.0"

--- a/tests/utils/test_strings.py
+++ b/tests/utils/test_strings.py
@@ -33,7 +33,9 @@ class TestStrings:
         assert not is_reserved("myname")
 
     def test_get_short_docstring(self) -> None:
+        assert get_short_docstring("") == ""
         assert get_short_docstring("\n") == ""
+        assert get_short_docstring("`asd\n:type") == "`asd`."
         assert (
             get_short_docstring(
                 """

--- a/tests/writers/test_boto3_stubs_package.py
+++ b/tests/writers/test_boto3_stubs_package.py
@@ -28,9 +28,7 @@ class TestBoto3StubsPackage:
 
         with tempfile.TemporaryDirectory() as output_dir:
             output_path = Path(output_dir)
-            result = write_boto3_stubs_package(package_mock, output_path, True)
-            assert len(result) == 31
-            assert result[0].name == "setup.py"
+            write_boto3_stubs_package(package_mock, output_path, True)
             render_jinja2_template_mock.assert_called_with(
                 Path("boto3-stubs/boto3-stubs/version.py.jinja2"),
                 package=package_mock,

--- a/tests/writers/test_boto3_stubs_package.py
+++ b/tests/writers/test_boto3_stubs_package.py
@@ -35,6 +35,18 @@ class TestBoto3StubsPackage:
             )
             assert len(blackify_mock.mock_calls) == 6
             assert len(sort_imports_mock.mock_calls) == 6
+            blackify_mock.reset_mock()
+            sort_imports_mock.reset_mock()
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_path = Path(output_dir)
+            write_boto3_stubs_package(package_mock, output_path, False)
+            render_jinja2_template_mock.assert_called_with(
+                Path("boto3-stubs/boto3-stubs/version.py.jinja2"),
+                package=package_mock,
+            )
+            assert len(blackify_mock.mock_calls) == 5
+            assert len(sort_imports_mock.mock_calls) == 5
 
     def test_write_boto3_stubs_docs(self) -> None:
         package_mock = MagicMock()
@@ -43,4 +55,6 @@ class TestBoto3StubsPackage:
 
         with tempfile.TemporaryDirectory() as output_dir:
             output_path = Path(output_dir)
+            (output_path / "module").mkdir(parents=True, exist_ok=True)
+            (output_path / "module" / "unknown.txt").touch()
             write_boto3_stubs_docs(package_mock, output_path)

--- a/tests/writers/test_botocore_stubs_package.py
+++ b/tests/writers/test_botocore_stubs_package.py
@@ -31,3 +31,14 @@ class TestBoto3StubsPackage:
             )
             assert len(blackify_mock.mock_calls) == 3
             assert len(sort_imports_mock.mock_calls) == 3
+            blackify_mock.reset_mock()
+            sort_imports_mock.reset_mock()
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_path = Path(output_dir)
+            write_botocore_stubs_package(output_path, False)
+            render_jinja2_template_mock.assert_called_with(
+                Path("botocore-stubs/botocore-stubs/version.py.jinja2")
+            )
+            assert len(blackify_mock.mock_calls) == 2
+            assert len(sort_imports_mock.mock_calls) == 2

--- a/tests/writers/test_botocore_stubs_package.py
+++ b/tests/writers/test_botocore_stubs_package.py
@@ -25,9 +25,7 @@ class TestBoto3StubsPackage:
 
         with tempfile.TemporaryDirectory() as output_dir:
             output_path = Path(output_dir)
-            result = write_botocore_stubs_package(output_path, True)
-            assert len(result) == 48
-            assert result[0].name == "setup.py"
+            write_botocore_stubs_package(output_path, True)
             render_jinja2_template_mock.assert_called_with(
                 Path("botocore-stubs/botocore-stubs/version.py.jinja2")
             )

--- a/tests/writers/test_master_package.py
+++ b/tests/writers/test_master_package.py
@@ -32,3 +32,17 @@ class TestMasterPackage:
             )
             assert len(blackify_mock.mock_calls) == 12
             assert len(sort_imports_mock.mock_calls) == 12
+            blackify_mock.reset_mock()
+            sort_imports_mock.reset_mock()
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_path = Path(output_dir)
+            (output_path / "package").mkdir(parents=True, exist_ok=True)
+            (output_path / "package" / "unknown.txt").touch()
+            write_master_package(package_mock, output_path, False)
+            render_jinja2_template_mock.assert_called_with(
+                Path("master/master/submodules.py.jinja2"),
+                package=package_mock,
+            )
+            assert len(blackify_mock.mock_calls) == 11
+            assert len(sort_imports_mock.mock_calls) == 11

--- a/tests/writers/test_master_package.py
+++ b/tests/writers/test_master_package.py
@@ -25,9 +25,7 @@ class TestMasterPackage:
 
         with tempfile.TemporaryDirectory() as output_dir:
             output_path = Path(output_dir)
-            result = write_master_package(package_mock, output_path, True)
-            assert len(result) == 14
-            assert result[0].name == "setup.py"
+            write_master_package(package_mock, output_path, True)
             render_jinja2_template_mock.assert_called_with(
                 Path("master/master/submodules.py.jinja2"),
                 package=package_mock,

--- a/tests/writers/test_processors.py
+++ b/tests/writers/test_processors.py
@@ -3,71 +3,109 @@ from unittest.mock import MagicMock, patch
 
 from mypy_boto3_builder.writers.processors import (
     process_boto3_stubs,
+    process_boto3_stubs_docs,
+    process_botocore_stubs,
     process_master,
     process_service,
+    process_service_docs,
 )
 
 
 class TestProcessors:
     @patch("mypy_boto3_builder.writers.processors.parse_boto3_stubs_package")
     @patch("mypy_boto3_builder.writers.processors.write_boto3_stubs_package")
-    @patch("mypy_boto3_builder.writers.processors.get_logger")
     def test_process_boto3_stubs(
         self,
-        _get_logger_mock: MagicMock,
         write_boto3_stubs_package_mock: MagicMock,
         parse_boto3_stubs_package_mock: MagicMock,
     ) -> None:
+        session_mock = MagicMock()
+        service_name_mock = MagicMock()
         write_boto3_stubs_package_mock.return_value = [Path("modified_path")]
-        result = process_boto3_stubs("session", Path("my_path"), ["service_name"], True)
+        result = process_boto3_stubs(session_mock, Path("my_path"), [service_name_mock], True)
         write_boto3_stubs_package_mock.assert_called_with(
             result,
             Path("my_path"),
             generate_setup=True,
         )
         parse_boto3_stubs_package_mock.assert_called_with(
-            session="session", service_names=["service_name"]
+            session=session_mock, service_names=[service_name_mock]
         )
         assert result == parse_boto3_stubs_package_mock()
 
     @patch("mypy_boto3_builder.writers.processors.parse_master_package")
     @patch("mypy_boto3_builder.writers.processors.write_master_package")
-    @patch("mypy_boto3_builder.writers.processors.get_logger")
     def test_process_master(
         self,
-        _get_logger_mock: MagicMock,
         write_master_package_mock: MagicMock,
         parse_master_package_mock: MagicMock,
     ) -> None:
         write_master_package_mock.return_value = [Path("modified_path")]
-        result = process_master("session", Path("my_path"), ["service_name"], True)
+        session_mock = MagicMock()
+        service_name_mock = MagicMock()
+        result = process_master(session_mock, Path("my_path"), [service_name_mock], True)
         write_master_package_mock.assert_called_with(
             result,
             output_path=Path("my_path"),
             generate_setup=True,
         )
-        parse_master_package_mock.assert_called_with("session", ["service_name"])
+        parse_master_package_mock.assert_called_with(session_mock, [service_name_mock])
         assert result == parse_master_package_mock()
 
     @patch("mypy_boto3_builder.writers.processors.parse_service_package")
     @patch("mypy_boto3_builder.writers.processors.write_service_package")
-    @patch("mypy_boto3_builder.writers.processors.get_logger")
     def test_process_service(
         self,
-        _get_logger_mock: MagicMock,
         write_service_package_mock: MagicMock,
         parse_service_package_mock: MagicMock,
     ) -> None:
-        write_service_package_mock.return_value = [
-            Path("modified_path"),
-            Path("client.py"),
-        ]
+        session_mock = MagicMock()
         service_name_mock = MagicMock()
-        result = process_service("session", service_name_mock, Path("my_path"), True)
+        parse_service_package_mock().typed_dicts = [MagicMock()]
+        result = process_service(session_mock, service_name_mock, Path("my_path"), True)
         write_service_package_mock.assert_called_with(
             result,
             output_path=Path("my_path"),
             generate_setup=True,
         )
-        parse_service_package_mock.assert_called_with("session", service_name_mock)
+        parse_service_package_mock.assert_called_with(session_mock, service_name_mock)
         assert result == parse_service_package_mock()
+
+    @patch("mypy_boto3_builder.writers.processors.parse_service_package")
+    @patch("mypy_boto3_builder.writers.processors.write_service_docs")
+    def test_process_service_docs(
+        self,
+        write_service_docs_mock: MagicMock,
+        parse_service_package_mock: MagicMock,
+    ) -> None:
+        session_mock = MagicMock()
+        service_name_mock = MagicMock()
+        result = process_service_docs(session_mock, service_name_mock, Path("my_path"))
+        write_service_docs_mock.assert_called_with(
+            result,
+            output_path=Path("my_path"),
+        )
+        parse_service_package_mock.assert_called_with(session_mock, service_name_mock)
+        assert result == parse_service_package_mock()
+
+    @patch("mypy_boto3_builder.writers.processors.parse_boto3_stubs_package")
+    @patch("mypy_boto3_builder.writers.processors.write_boto3_stubs_docs")
+    def test_process_boto3_stubs_docs(
+        self,
+        write_boto3_stubs_docs_mock: MagicMock,
+        parse_boto3_stubs_package_mock: MagicMock,
+    ) -> None:
+        session_mock = MagicMock()
+        service_name_mock = MagicMock()
+        result = process_boto3_stubs_docs(session_mock, Path("my_path"), [service_name_mock])
+        write_boto3_stubs_docs_mock.assert_called_with(
+            result,
+            output_path=Path("my_path"),
+        )
+        parse_boto3_stubs_package_mock.assert_called_with(session_mock, [service_name_mock])
+        assert result == parse_boto3_stubs_package_mock()
+
+    @patch("mypy_boto3_builder.writers.processors.write_botocore_stubs_package")
+    def test_process_botocore_stubs(self, write_botocore_stubs_package: MagicMock) -> None:
+        process_botocore_stubs(Path("my_path"), False)
+        write_botocore_stubs_package.assert_called_with(Path("my_path"), generate_setup=False)

--- a/tests/writers/test_service_package.py
+++ b/tests/writers/test_service_package.py
@@ -33,6 +33,21 @@ class TestServicePackage:
             )
             assert len(blackify_mock.mock_calls) == 17
             assert len(sort_imports_mock.mock_calls) == 17
+            blackify_mock.reset_mock()
+            sort_imports_mock.reset_mock()
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_path = Path(output_dir)
+            (output_path / "package").mkdir(parents=True, exist_ok=True)
+            (output_path / "package" / "unknown.txt").touch()
+            write_service_package(package_mock, output_path, False)
+            render_jinja2_template_mock.assert_called_with(
+                Path("service/service/type_defs.pyi.jinja2"),
+                package=package_mock,
+                service_name=package_mock.service_name,
+            )
+            assert len(blackify_mock.mock_calls) == 16
+            assert len(sort_imports_mock.mock_calls) == 16
 
     def test_write_service_docs(self) -> None:
         package_mock = MagicMock()
@@ -41,4 +56,6 @@ class TestServicePackage:
 
         with tempfile.TemporaryDirectory() as output_dir:
             output_path = Path(output_dir)
+            (output_path / "module").mkdir(parents=True, exist_ok=True)
+            (output_path / "module" / "unknown.txt").touch()
             write_service_docs(package_mock, output_path)

--- a/tests/writers/test_service_package.py
+++ b/tests/writers/test_service_package.py
@@ -25,9 +25,7 @@ class TestServicePackage:
 
         with tempfile.TemporaryDirectory() as output_dir:
             output_path = Path(output_dir)
-            result = write_service_package(package_mock, output_path, True)
-            assert len(result) == 19
-            assert result[0].name == "setup.py"
+            write_service_package(package_mock, output_path, True)
             render_jinja2_template_mock.assert_called_with(
                 Path("service/service/type_defs.pyi.jinja2"),
                 package=package_mock,

--- a/tests/writers/test_utils.py
+++ b/tests/writers/test_utils.py
@@ -13,7 +13,7 @@ from mypy_boto3_builder.writers.utils import (
 
 class TestUtils:
     @patch("mypy_boto3_builder.writers.utils.black")
-    def test_blackify(self, black_mock):
+    def test_blackify(self, black_mock: MagicMock):
         file_path_mock = MagicMock()
         file_path_mock.suffix = ".txt"
         result = blackify("my content", file_path_mock)
@@ -37,10 +37,11 @@ class TestUtils:
         assert blackify("my content", file_path_mock) == "my content"
 
     @patch("mypy_boto3_builder.writers.utils.sort_code_string")
-    def test_sort_imports(self, sort_code_string_mock):
+    def test_sort_imports(self, sort_code_string_mock: MagicMock):
         sort_code_string_mock.return_value = "output"
         assert sort_imports("test", "mymodule") == "output"
         sort_code_string_mock.assert_called()
+        assert sort_imports("test", "boto3") == "output"
 
     @patch("mypy_boto3_builder.writers.utils.TEMPLATES_PATH")
     @patch("mypy_boto3_builder.writers.utils.JinjaManager")
@@ -48,19 +49,21 @@ class TestUtils:
         self, JinjaManagerMock: MagicMock, TEMPLATES_PATH_MOCK: MagicMock
     ) -> None:
         template_path_mock = MagicMock()
-        result = render_jinja2_template(template_path_mock, "package", "service_name")
+        package_mock = MagicMock()
+        service_name_mock = MagicMock()
+        result = render_jinja2_template(template_path_mock, package_mock, service_name_mock)
         JinjaManagerMock.get_environment.assert_called_with()
         JinjaManagerMock.get_environment().get_template.assert_called_with(
             template_path_mock.as_posix()
         )
         JinjaManagerMock.get_environment().get_template().render.assert_called_with(
-            package="package", service_name="service_name"
+            package=package_mock, service_name=service_name_mock
         )
         assert result == JinjaManagerMock.get_environment().get_template().render()
 
         TEMPLATES_PATH_MOCK.__truediv__().exists.return_value = False
         with pytest.raises(ValueError):
-            render_jinja2_template(template_path_mock, "package", "service_name")
+            render_jinja2_template(template_path_mock, package_mock, service_name_mock)
 
     def test_insert_md_toc(self) -> None:
         assert (


### PR DESCRIPTION
### Added
- `[builder]` Supported services are no longer hardcoded, so no need to add new services
- `[builder]` `--list-services` CLI flag to output a list of supported services
- `[ci]` `Sanity check` workflow to check generated packages daily

### Changed
- `[boto3-stubs]` Doc links now point to latest `boto3` docs
- `[botocore-stubs]` Doc links now point to latest `boto3` docs
- `[ci]` `check_output` runs tests with `mypy` as well
- `[boto3-stubs]` Requires non-strict versions of subpackages, five micro releases below the current (should fix `conda-forge` builds)
- `[docker]` Uses strict `regex==2021.7.6` package version

### Fixed
- `[boto3-stubs]` Removed Generics from  `boto3.resouces.collection`
- `[builder]` Potential infinite recursion while working with paths
- `[builder]` Removed aggressive cleanup of unused generated files