### PR TITLE
Use dedicated urllib3 type stubs

### DIFF
--- a/mypy_boto3_builder/botocore_stubs_static/awsrequest.pyi
+++ b/mypy_boto3_builder/botocore_stubs_static/awsrequest.pyi
@@ -6,8 +6,8 @@ from botocore.compat import urlencode as urlencode
 from botocore.compat import urlsplit as urlsplit
 from botocore.compat import urlunsplit as urlunsplit
 from botocore.exceptions import UnseekableStreamError as UnseekableStreamError
-from requests.packages.urllib3.connection import HTTPConnection, VerifiedHTTPSConnection
-from requests.packages.urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.connection import HTTPConnection, VerifiedHTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 try:
     from collections.abc import MutableMapping

--- a/mypy_boto3_builder/botocore_stubs_static/exceptions.pyi
+++ b/mypy_boto3_builder/botocore_stubs_static/exceptions.pyi
@@ -2,8 +2,8 @@ import sys
 from typing import IO, Any, Dict, Iterable, Mapping
 
 import requests
-import urllib3  # type: ignore
-from urllib3.exceptions import ReadTimeoutError as _ReadTimeoutError  # type: ignore
+import urllib3
+from urllib3.exceptions import ReadTimeoutError as _ReadTimeoutError
 
 if sys.version_info >= (3, 9):
     from typing import TypedDict

--- a/mypy_boto3_builder/botocore_stubs_static/httpsession.pyi
+++ b/mypy_boto3_builder/botocore_stubs_static/httpsession.pyi
@@ -10,7 +10,7 @@ from botocore.exceptions import InvalidProxiesConfigError as InvalidProxiesConfi
 from botocore.exceptions import ProxyConnectionError as ProxyConnectionError
 from botocore.exceptions import ReadTimeoutError as ReadTimeoutError
 from botocore.exceptions import SSLError as SSLError
-from requests.packages.urllib3 import ProxyManager as ProxyManager
+from urllib3 import ProxyManager as ProxyManager
 
 DEFAULT_TIMEOUT: int
 MAX_POOL_CONNECTIONS: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ twine = "*"
 types-requests = "*"
 types-pkg-resources = "*"
 types-six = "*"
+types-urllib3 = "*"
 boto3-stubs = "*"
 botocore-stubs = "*"
 


### PR DESCRIPTION
@vemel unfortunately I'm not entirely sure how to test this, or whether I got the dependencies quite right.

---

See python/typeshed#6893. The `request.packages.urllib3` module no
longer has type stubs, but there are dedicated type stubs for `urllib3`
that can be used instead.